### PR TITLE
Alpha order routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version History
 ======
     * All Version bumps are required to update this file as well!!
 
+    * 2.1.2 - Sort the list for readability
     * 2.1.1 - Style updates for open sourcing the gem
     * 2.1.0 - Including assets
     * 2.0.0 - Re-writing the routes logic to include those held in engines

--- a/app/controllers/routes_revealer/routes_controller.rb
+++ b/app/controllers/routes_revealer/routes_controller.rb
@@ -16,7 +16,8 @@ module RoutesRevealer
       output = []
       output += [asset_route]
       output += map_routes(Rails.application.routes.routes).flatten
-      output.compact!.uniq!.sort!
+      output.compact!.uniq!
+      output.sort! if output
       render json: output
     end
 

--- a/app/controllers/routes_revealer/routes_controller.rb
+++ b/app/controllers/routes_revealer/routes_controller.rb
@@ -16,7 +16,7 @@ module RoutesRevealer
       output = []
       output += [asset_route]
       output += map_routes(Rails.application.routes.routes).flatten
-      output.compact!.uniq!
+      output.compact!.uniq!.sort!
       render json: output
     end
 

--- a/lib/routes_revealer/version.rb
+++ b/lib/routes_revealer/version.rb
@@ -9,5 +9,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 module RoutesRevealer
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end

--- a/spec/controllers/routes_controller_spec.rb
+++ b/spec/controllers/routes_controller_spec.rb
@@ -66,11 +66,11 @@ describe RoutesRevealer::RoutesController do
 
     it { expect(response.status).to eq 200 }
     it { expect(JSON.parse(response.body).length).to eq 9 }
-    it { expect(JSON.parse(response.body)[0]).to eq "/assets" }
-    it { expect(JSON.parse(response.body)[1]).to eq "/1" }
-    it { expect(JSON.parse(response.body)[2]).to eq "/2" }
-    it { expect(JSON.parse(response.body)[3]).to eq "/3" }
-    it { expect(JSON.parse(response.body)[4]).to eq "/4" }
+    it { expect(JSON.parse(response.body)[0]).to eq "/1" }
+    it { expect(JSON.parse(response.body)[1]).to eq "/2" }
+    it { expect(JSON.parse(response.body)[2]).to eq "/3" }
+    it { expect(JSON.parse(response.body)[3]).to eq "/4" }
+    it { expect(JSON.parse(response.body)[4]).to eq "/assets" }
     it { expect(JSON.parse(response.body)[5]).to eq "/t1" }
     it { expect(JSON.parse(response.body)[6]).to eq "/t2" }
     it { expect(JSON.parse(response.body)[7]).to eq "/that/1" }


### PR DESCRIPTION
Alphabetize the routes that come out of routes revealer to help readability.

Before:
![screenshot 2015-11-19 15 11 13](https://cloud.githubusercontent.com/assets/882850/11282909/d85a8af2-8ecf-11e5-9d83-00fed184f394.png)

After:
![screenshot 2015-11-19 15 11 27](https://cloud.githubusercontent.com/assets/882850/11282914/dd6a61b6-8ecf-11e5-809d-58078ffb0d8d.png)
